### PR TITLE
Remove DB roles and reorganize 

### DIFF
--- a/database.yaml
+++ b/database.yaml
@@ -1,0 +1,13 @@
+---
+- name: Deploy Galera DB server for zabbix
+  hosts: galera-cluster-nodes
+  remote_user: centos
+  become: yes
+  pre_tasks:
+    - name: ensure everything is upto date
+      yum:
+        name: '*'
+        state: latest
+  roles:
+    - role: ansible-mariadb-galera-cluster
+  

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,0 +1,5 @@
+zabbix_server_dbname: zabbix
+zabbix_server_dbuser: zbx
+zabbix_server_dbpassword: 'SuperSecure'
+zabbix_url: zabbix.johnward.us
+#state: enabled

--- a/group_vars/galera-cluster-nodes.yaml
+++ b/group_vars/galera-cluster-nodes.yaml
@@ -1,0 +1,10 @@
+galera_cluster_name: 'zabbix'
+postgresql_databases:
+  - name: 'zabbix'
+mariadb_mysql_users:
+  - name: 'zbx'
+    hosts: 
+      - '%'
+    password: 'SuperSecure'
+mariadb_mysql_root_password: 'SomthingOtherThanDefault'
+galera_cluster_bind_interface: 'eth1'

--- a/zabbix.yml
+++ b/zabbix.yml
@@ -1,29 +1,19 @@
 ---
-  - hosts: all
-    remote_user: centos
-    become: yes
-    vars:
-      zabbix_server_dbname: zabbix
-      zabbix_server_dbuser: zbx
-      zabbix_server_dbpassword: 'SuperSecure'
-      zabbix_url: zabbixserver.com
-      postgresql_databases:
-        - name: zabbix
-      postgresql_users:
-        - name: zbx
-          password: 'SuperSecure'
-      policy_files:
-        - ~/Documents/Ansible/selinux/httpd_t.te
-        - ~/Documents/Ansible/selinux/zabbix_t.te
-      state: enabled
-    tasks:
-      - name: Install Zabbix agent.
-        yum:
-          name: zabbix-agent
-          state: present
-    roles:
-     - geerlingguy.postgresql
-     - geerlingguy.apache
-     - dj-wasabi.zabbix-server
-     - dj-wasabi.zabbix-web
-     - selinux-module
+- name: Deploy Zabbix sever
+  hosts: zabbix-server
+  remote_user: centos
+  become: yes
+  pre_tasks:
+    - name: Update SELinux Booleans
+      seboolean:
+        name: "{{ item.name }}"
+        persistent: yes
+        state: "{{ item.state }}"
+      with_items:
+        - { name: "httpd_can_network_connect_db", state: yes }
+        - { name: "daemons_enable_cluster_mode", state: yes }
+  roles:
+    - role: geerlingguy.apache
+    - role: dj-wasabi.zabbix-server
+    - role: dj-wasabi.zabbix-web
+    #- selinux-module


### PR DESCRIPTION
1. This makes some changes in the way that the repo is organized,
breaking out the variables into group_vars
2. Remove the role for setting boolean permissions and move that to using
the builtin seboolean module (May not work, haven't fully tested)
3. Break out the database deployment to a seperate role we are going to be
using galera for the database backend.